### PR TITLE
Fix bug that prevented forced datetime objects to become SQLAlchemy Date() columns

### DIFF
--- a/src/petlx/sql.py
+++ b/src/petlx/sql.py
@@ -97,14 +97,14 @@ def make_sqlalchemy_column(col, colname, constraints=True):
     elif all(isinstance(v, (int, long, float)) for v in col_not_none):
         sql_column_type = sqlalchemy.Float
 
+    elif all(isinstance(v, datetime.datetime) for v in col_not_none):
+        sql_column_type = sqlalchemy.DateTime
+
     elif all(isinstance(v, datetime.date) for v in col_not_none):
         sql_column_type = sqlalchemy.Date
 
     elif all(isinstance(v, datetime.time) for v in col_not_none):
         sql_column_type = sqlalchemy.Time
-
-    elif all(isinstance(v, datetime.datetime) for v in col_not_none):
-        sql_column_type = sqlalchemy.DateTime
 
     else:
         sql_column_type = sqlalchemy.String

--- a/src/petlx/test/test_sql.py
+++ b/src/petlx/test/test_sql.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from petlx.sql import make_sqlalchemy_column
+from petl.testutils import eq_
+from datetime import datetime, date
+from sqlalchemy import Column, DateTime, Date
+
+
+def test_make_datetime_column():
+    sql_col = make_sqlalchemy_column([datetime(2014, 1, 1, 1, 1, 1, 1),
+                                      datetime(2014, 1, 1, 1, 1, 1, 2)],
+                                     'name')
+    expect = Column('name', DateTime(), nullable=False)
+    eq_(str(expect.type), str(sql_col.type))
+
+
+def test_make_date_column():
+    sql_col = make_sqlalchemy_column([date(2014, 1, 1),
+                                      date(2014, 1, 2)],
+                                     'name')
+    expect = Column('name', Date(), nullable=False)
+    eq_(str(expect.type), str(sql_col.type))
+
+if __name__ == "__main__":
+    test_make_date_column()
+    test_make_datetime_column()


### PR DESCRIPTION
Since datetime objects are instances of the date class, the order of checking for types is important.  Since check against date came before datetime, that check returned true.  The fix is simple:  move the check for datetime to come before the check for date.  This fixes #66.
